### PR TITLE
Fixed Typo In Dashboard Component

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -357,7 +357,7 @@ class Dashboard extends Component {
                             variant="subtitle2"
                             gutterBottom
                           >
-                            Othe type
+                            Other type
                           </Typography>
                           <Typography
                             className={classes.inlining}


### PR DESCRIPTION
There was a typo 'Othe Type' on [line:360](https://github.com/alexanmtz/material-sense/compare/master...huzaifa-99:fix/typo-dashboard-page#diff-77509e4563ca02092d13dc61a97f9350d12b27753d6f36a0912b58d29d745c8cR360), Fixed it with 'Other Type'.